### PR TITLE
Fix dbt package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ or open PRs against `master`. Check out
 on the best workflow for contributing to a package.
 
 ## Resources:
+- Find all of Fivetran's pre-built dbt packages in our [dbt hub](https://hub.getdbt.com/fivetran/)
 - Learn more about Fivetran [here](https://fivetran.com/docs)
 - Check out [Fivetran's blog](https://fivetran.com/blog)
 - Learn more about dbt [in the docs](https://docs.getdbt.com/docs/introduction)

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# LinkedIn Ads 
+# LinkedIn Ad Analytics 
 
-This package models LinkedIn Ads data from [Fivetran's connector](https://fivetran.com/docs/applications/linkedin-ads). It uses data in the format described by [this ERD](https://docs.google.com/presentation/d/1nwR5efra1p3S1uOwUgU9Wdx7WBKXE7onxNDffK0IpgM/edit#slide=id.g311502b468_5_443).
+This package models LinkedIn Ad Analytics data from [Fivetran's connector](https://fivetran.com/docs/applications/linkedin-ads). It uses data in the format described by [this ERD](https://docs.google.com/presentation/d/1nwR5efra1p3S1uOwUgU9Wdx7WBKXE7onxNDffK0IpgM/edit#slide=id.g311502b468_5_443).
 
 The main focus of the package is to transform the core ad object tables into analytics-ready models, including an 'ad adapter' model that can be easily unioned in to other ad platform packages to get a single view. 
 
 ## Models
 
-This package contains transformation models, designed to work simultaneously with our [LinkedIn Ads source package](https://github.com/fivetran/dbt_linkedin_source). A dependency on the source package is declared in this package's `packages.yml` file, so it will automatically download when you run `dbt deps`. The primary outputs of this package are described below.
+This package contains transformation models, designed to work simultaneously with our [LinkedIn Ad Analytics source package](https://github.com/fivetran/dbt_linkedin_source). A dependency on the source package is declared in this package's `packages.yml` file, so it will automatically download when you run `dbt deps`. The primary outputs of this package are described below.
 
 | **model**                          | **description**                                                                                                        |
 | ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
@@ -19,7 +19,7 @@ This package contains transformation models, designed to work simultaneously wit
 Check [dbt Hub](https://hub.getdbt.com/) for the latest installation instructions, or [read the dbt docs](https://docs.getdbt.com/docs/package-management) for more information on installing packages.
 
 ## Configuration
-By default, this package will look for your LinkedIn Ads data in the `linkedin_ads` schema of your [target database](https://docs.getdbt.com/docs/running-a-dbt-project/using-the-command-line-interface/configure-your-profile). If this is not where your LinkedIn Ads data is, please add the following configuration to your `dbt_project.yml` file:
+By default, this package will look for your LinkedIn Ad Analytics data in the `linkedin_ads` schema of your [target database](https://docs.getdbt.com/docs/running-a-dbt-project/using-the-command-line-interface/configure-your-profile). If this is not where your LinkedIn Ad Analytics data is, please add the following configuration to your `dbt_project.yml` file:
 
 ```yml
 # dbt_project.yml
@@ -32,7 +32,7 @@ vars:
     linkedin_database: your_schema_name 
 ```
 
-For additional configurations for the source models, please visit the [Linkedin source package](https://github.com/fivetran/dbt_linkedin_source).
+For additional configurations for the source models, please visit the [LinkedIn Ad Analytics source package](https://github.com/fivetran/dbt_linkedin_source).
 
 ## Contributions
 


### PR DESCRIPTION
Updates dbt package name to match [our connector documentation](https://fivetran.com/docs/applications/linkedin-ads). Also, adds link to Fivetran dbt hub.