### PR TITLE
Update freshness config

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/maintainer_pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/maintainer_pull_request_template.md
@@ -1,29 +1,35 @@
-## PR Overview
-**This PR will address the following Issue/Feature:**
+<!--
+Pre-Submission Reminders  
+Before marking this PR as "ready for review":
 
-**This PR will result in the following new package version:**
-<!--- Please add details around your decision for breaking vs non-breaking version upgrade. If this is a breaking change, were backwards-compatible options explored? -->
+- `dbt run --full-refresh && dbt test`  
+- `dbt run` && `dbt test` (if incremental models are present)  
+- The related issue is linked, tagged, and appropriately assigned  
+- Documentation and version updates are included, if applicable  
+- `docs` have been regenerated (unless there are no code or YAML changes)  
+- BuildKite integration tests are passing
+-->
 
-**Please provide the finalized CHANGELOG entry which details the relevant changes included in this PR:**
-<!--- Copy/paste the CHANGELOG for this version below. -->
+## PR Overview 
+**Package version introduced in this PR:** 
+ 
+**This PR addresses the following Issue/Feature(s):**
+<!-- Add Issue # or internal ticket reference -->
 
-## PR Checklist
-### Basic Validation
-Please acknowledge that you have successfully performed the following commands locally:
-- [ ] dbt run –full-refresh && dbt test
-- [ ] dbt run (if incremental models are present) && dbt test
+**Summary of changes:**  
+<!-- 1-2 sentences describing PR changes. -->
 
-Before marking this PR as "ready for review" the following have been applied:
-- [ ] The appropriate issue has been linked, tagged, and properly assigned
-- [ ] All necessary documentation and version upgrades have been applied
-- [ ] docs were regenerated (unless this PR does not include any code or yml updates)
-- [ ] BuildKite integration tests are passing
-- [ ] Detailed validation steps have been provided below
 
-### Detailed Validation
-Please share any and all of your validation steps:
-<!--- Provide the steps you took to validate your changes below. -->
+### Submission Checklist  
+- [ ] Alignment meeting with the reviewer (if needed)  
+  - [ ] Timeline and validation requirements discussed  
+- [ ] Provide validation details:  
+  - [ ] **Validation Steps:** Check for unintentional effects (e.g., add/run consistency & integrity tests)
+  - [ ] **Testing Instructions:** Confirm the change addresses the issue(s)
+  - [ ] **Focus Areas:** Complex logic or queries that need extra attention  
 
-### If you had to summarize this PR in an emoji, which would it be?
-<!--- For a complete list of markdown compatible emojis check our this git repo (https://gist.github.com/rxaviers/7360908)  --> 
-:dancer:
+### Changelog  
+<!-- Recommend drafting changelog notes, then refining via ChatGPT using:  
+"Draft a changelog entry based on the following notes." -->
+- [ ] Draft changelog for PR  
+- [ ] Final changelog for release review

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,29 @@
+# dbt_linkedin v0.12.0
+
+[PR #45](https://github.com/fivetran/dbt_linkedin/pull/45) includes the following updates:
+
+## Breaking Change for dbt Core < 1.9.5
+> *Note: This is not relevant to Fivetran Quickstart users.*
+
+Migrated `freshness` from a top-level source property to a source `config` in alignment with [recent updates](https://github.com/dbt-labs/dbt-core/issues/11506) from dbt Core ([Source PR #75](https://github.com/fivetran/dbt_linkedin_source/pull/75)). This will resolve the following deprecation warning that users running dbt >= 1.9.5 may have received:
+
+```
+[WARNING]: Deprecated functionality
+Found `freshness` as a top-level property of `linkedin_ads` in file
+`models/src_linkedin.yml`. The `freshness` top-level property should be moved
+into the `config` of `linkedin_ads`.
+```
+
+**IMPORTANT:** Users running dbt Core < 1.9.5 will not be able to utilize freshness tests in this release or any subsequent releases, as older versions of dbt will not recognize freshness as a source `config` and therefore not run the tests.
+
+If you are using dbt Core < 1.9.5 and want to continue running Linkedin Ads freshness tests, please elect **one** of the following options:
+  1. (Recommended) Upgrade to dbt Core >= 1.9.5
+  2. Do not upgrade your installed version of the `linkedin` package. Pin your dependency on v0.11.0 in your `packages.yml` file.
+  3. Utilize a dbt [override](https://docs.getdbt.com/reference/resource-properties/overrides) to overwrite the package's `linkedin_ads` source and apply freshness via the [old](https://github.com/fivetran/dbt_linkedin_source/blob/v0.11.0/models/src_linkedin.yml#L10-L12) top-level property route. This will require you to copy and paste the entirety of the `src_linkedin.yml` [file](https://github.com/fivetran/dbt_linkedin_source/blob/v0.11.0/models/src_linkedin.yml#L5-L377) and add an `overrides: linkedin_source` property.
+
+## Under the Hood
+- Updated the package maintainer PR template.
+
 # dbt_linkedin v0.11.0
 
 [PR #44](https://github.com/fivetran/dbt_linkedin/pull/44) includes the following updates:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,10 @@
 
 [PR #45](https://github.com/fivetran/dbt_linkedin/pull/45) includes the following updates:
 
-## Breaking Change for dbt Core < 1.9.5
+## Breaking Change for dbt Core < 1.9.6
 > *Note: This is not relevant to Fivetran Quickstart users.*
 
-Migrated `freshness` from a top-level source property to a source `config` in alignment with [recent updates](https://github.com/dbt-labs/dbt-core/issues/11506) from dbt Core ([Source PR #75](https://github.com/fivetran/dbt_linkedin_source/pull/75)). This will resolve the following deprecation warning that users running dbt >= 1.9.5 may have received:
+Migrated `freshness` from a top-level source property to a source `config` in alignment with [recent updates](https://github.com/dbt-labs/dbt-core/issues/11506) from dbt Core ([Source PR #75](https://github.com/fivetran/dbt_linkedin_source/pull/75)). This will resolve the following deprecation warning that users running dbt >= 1.9.6 may have received:
 
 ```
 [WARNING]: Deprecated functionality
@@ -14,10 +14,10 @@ Found `freshness` as a top-level property of `linkedin_ads` in file
 into the `config` of `linkedin_ads`.
 ```
 
-**IMPORTANT:** Users running dbt Core < 1.9.5 will not be able to utilize freshness tests in this release or any subsequent releases, as older versions of dbt will not recognize freshness as a source `config` and therefore not run the tests.
+**IMPORTANT:** Users running dbt Core < 1.9.6 will not be able to utilize freshness tests in this release or any subsequent releases, as older versions of dbt will not recognize freshness as a source `config` and therefore not run the tests.
 
-If you are using dbt Core < 1.9.5 and want to continue running Linkedin Ads freshness tests, please elect **one** of the following options:
-  1. (Recommended) Upgrade to dbt Core >= 1.9.5
+If you are using dbt Core < 1.9.6 and want to continue running Linkedin Ads freshness tests, please elect **one** of the following options:
+  1. (Recommended) Upgrade to dbt Core >= 1.9.6
   2. Do not upgrade your installed version of the `linkedin` package. Pin your dependency on v0.11.0 in your `packages.yml` file.
   3. Utilize a dbt [override](https://docs.getdbt.com/reference/resource-properties/overrides) to overwrite the package's `linkedin_ads` source and apply freshness via the [old](https://github.com/fivetran/dbt_linkedin_source/blob/v0.11.0/models/src_linkedin.yml#L10-L12) top-level property route. This will require you to copy and paste the entirety of the `src_linkedin.yml` [file](https://github.com/fivetran/dbt_linkedin_source/blob/v0.11.0/models/src_linkedin.yml#L5-L377) and add an `overrides: linkedin_source` property.
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Include the following Linkedin Ads package version in your `packages.yml` file:
 # packages.yml
 packages:
   - package: fivetran/linkedin
-    version: [">=0.11.0", "<0.12.0"]
+    version: [">=0.12.0", "<0.13.0"]
 ```
 Do **NOT** include the `linkedin_source` package in this file. The transformation package itself has a dependency on it and will install the source package as well.
 
@@ -189,7 +189,7 @@ This dbt package is dependent on the following dbt packages. These dependencies 
 ```yml
 packages:
     - package: fivetran/linkedin_source
-      version: [">=0.11.0", "<0.12.0"]
+      version: [">=0.12.0", "<0.13.0"]
     - package: fivetran/fivetran_utils
       version: [">=0.4.0", "<0.5.0"]
     - package: dbt-labs/dbt_utils

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'linkedin'
-version: '0.11.0'
+version: '0.12.0'
 config-version: 2
 require-dbt-version: [">=1.3.0", "<2.0.0"]
 vars:

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'linkedin_integration_tests'
-version: '0.11.0'
+version: '0.12.0'
 profile: 'integration_tests'
 config-version: 2
 

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,5 @@
 packages:
-  - package: fivetran/linkedin_source
-    version: [">=0.11.0", "<0.12.0"]
+  # - package: fivetran/linkedin_source
+  #   version: [">=0.12.0", "<0.13.0"]
+  - git: https://github.com/fivetran/dbt_linkedin_source.git
+    revision: feature/update-freshness-config

--- a/packages.yml
+++ b/packages.yml
@@ -1,5 +1,3 @@
 packages:
-  # - package: fivetran/linkedin_source
-  #   version: [">=0.12.0", "<0.13.0"]
-  - git: https://github.com/fivetran/dbt_linkedin_source.git
-    revision: feature/update-freshness-config
+  - package: fivetran/linkedin_source
+    version: [">=0.12.0", "<0.13.0"]


### PR DESCRIPTION
<!--
Pre-Submission Reminders  
Before marking this PR as "ready for review":

- `dbt run --full-refresh && dbt test`  
- `dbt run` && `dbt test` (if incremental models are present)  
- The related issue is linked, tagged, and appropriately assigned  
- Documentation and version updates are included, if applicable  
- `docs` have been regenerated (unless there are no code or YAML changes)  
- BuildKite integration tests are passing
-->

## PR Overview 
**Package version introduced in this PR:** 
 v0.12.0

**This PR addresses the following Issue/Feature(s):**
<!-- Add Issue # or internal ticket reference -->
https://github.com/fivetran/dbt_ad_reporting/issues/148

**Summary of changes:**  
<!-- 1-2 sentences describing PR changes. -->
Updates freshness to align with the new config framework introduced in dbt Core v1.9. Documents how users on older versions of dbt Core will/can interface with freshness

### Submission Checklist  
- [ ] Alignment meeting with the reviewer (if needed)  
  - [ ] Timeline and validation requirements discussed  
- [x] Provide validation details:  
  - [x] **Validation Steps:** Check for unintentional effects (e.g., add/run consistency & integrity tests)

older versions of dbt do not run freshness tests, but there's no error message
![image](https://github.com/user-attachments/assets/f16a54ed-8cb8-4dcf-a3f3-c7a9a19d30b7)

  - [x] **Testing Instructions:** Confirm the change addresses the issue(s)

dbt v1.9 prior to our update: freshness tests run but there's a deprecation message for some folks (idk why I am not getting it despite being on dbt v1.9.8?)
![image](https://github.com/user-attachments/assets/02df1efa-48d5-4aa7-ae4d-f5498001a9d3)

dbt v1.9 with our update: successfully runs freshness without any deprecation notice
![image](https://github.com/user-attachments/assets/699c27cd-40c9-48c5-8b71-274a2db527d1)

  - [ ] **Focus Areas:** Complex logic or queries that need extra attention  

### Changelog  
<!-- Recommend drafting changelog notes, then refining via ChatGPT using:  
"Draft a changelog entry based on the following notes." -->
- [x] Draft changelog for PR  
- [ ] Final changelog for release review